### PR TITLE
[MM-24405] Adds rawSql vet check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ This repository contains mattermost-specific go-vet rules that are used to maint
 1. **structuredLogging** - check invalid usage of logging (must use structured logging)
 1. **tFatal** - check invalid usage of t.Fatal assertions (instead of testify methods)
 1. **apiAuditLogs** - check that audit records are properly created in the API layer
+1. **rawSql** - check invalid usage of raw SQL queries instead of using the squirrel lib

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mattermost/mattermost-govet/inconsistentReceiverName"
 	"github.com/mattermost/mattermost-govet/license"
 	"github.com/mattermost/mattermost-govet/openApiSync"
+	"github.com/mattermost/mattermost-govet/rawSql"
 	"github.com/mattermost/mattermost-govet/structuredLogging"
 	"github.com/mattermost/mattermost-govet/tFatal"
 	"golang.org/x/tools/go/analysis/unitchecker"
@@ -20,6 +21,7 @@ func main() {
 		tFatal.Analyzer,
 		equalLenAsserts.Analyzer,
 		openApiSync.Analyzer,
+		rawSql.Analyzer,
 		inconsistentReceiverName.Analyzer,
 		apiAuditLogs.Analyzer,
 	)

--- a/rawSql/rawSql.go
+++ b/rawSql/rawSql.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rawSql
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const sqlstorePackagePath = "github.com/mattermost/mattermost-server/v5/store/sqlstore"
+
+var Analyzer = &analysis.Analyzer{
+	Name: "rawSql",
+	Doc: "check invalid usage of raw SQL queries instead of using the squirrel lib",
+	Run: run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	if !strings.HasPrefix(pass.Pkg.Path(), sqlstorePackagePath) {
+		return nil, nil
+	}
+
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.BasicLit:
+				if n.Kind != token.STRING {
+					return false
+				}
+
+				unquoted, err := strconv.Unquote(n.Value)
+				if err != nil {
+					return false
+				}
+
+				words := strings.Fields(strings.TrimSpace(unquoted))
+				if len(words) == 0 {
+					return false
+				}
+
+				switch lead := strings.ToLower(words[0]); lead {
+				case "select":
+					pass.Reportf(n.Pos(), "Found leading \"select\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
+				case "insert":
+					pass.Reportf(n.Pos(), "Found leading \"insert\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
+				case "update":
+					pass.Reportf(n.Pos(), "Found leading \"update\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
+				}
+				return false
+			}
+			return true
+		})
+	}
+	return nil, nil
+}

--- a/rawSql/rawSql.go
+++ b/rawSql/rawSql.go
@@ -44,12 +44,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				}
 
 				switch lead := strings.ToLower(words[0]); lead {
-				case "select":
-					pass.Reportf(n.Pos(), "Found leading \"select\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
-				case "insert":
-					pass.Reportf(n.Pos(), "Found leading \"insert\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
-				case "update":
-					pass.Reportf(n.Pos(), "Found leading \"update\" in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.")
+				case "select", "insert", "update":
+					pass.Reportf(n.Pos(), "Found leading %q in a string. Creating raw SQL queries is not allowed, please use the squirrel builder instead.", lead)
 				}
 				return false
 			}


### PR DESCRIPTION
#### Summary
Adds a `rawSql` analyzer that searches the `sqlstore` package and reports all the query strings starting with `insert`, `update` and `select`.

Delete queries are used more widely in tests and other parts of the application, so they are excluded in this iteration, although we may want to add them later.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24405
