### PR TITLE
Add `api/v4/remotecluster` to list of endpoints excluded from docs

### DIFF
--- a/openApiSync/openApiSync.go
+++ b/openApiSync/openApiSync.go
@@ -29,7 +29,7 @@ var (
 
 	specFile         string
 	groupSplitRegexp = regexp.MustCompile(`{([a-z_]*):([a-z_]*)\|([a-z_]*)}`)
-	IgnoredCases     = []string{"websocket:websocket"}
+	IgnoredCases     = []string{"websocket:websocket", "api/v4/remotecluster"}
 )
 
 func init() {


### PR DESCRIPTION
#### Summary
Three new endpoints have been added to server that Product Mgmt has agreed should not be documented.  https://github.com/mattermost/mattermost-api-reference/pull/589#issuecomment-736837539

api/v4/remotecluster/msg
api/v4/remotecluster/confirm_invite
api/v4/remotecluster/ping

This PR is to exclude these from the govet documentation check.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31001