### PR TITLE
Adding error vars check

### DIFF
--- a/errorVars/errorVars.go
+++ b/errorVars/errorVars.go
@@ -16,7 +16,7 @@ const (
 
 var Analyzer = &analysis.Analyzer{
 	Name: "errorVars",
-	Doc:  "check for non valid type assignations to err and appErr prefixed variables",
+	Doc:  "check for non valid type assignments to err and appErr prefixed variables",
 	Run:  run,
 }
 

--- a/errorVars/errorVars.go
+++ b/errorVars/errorVars.go
@@ -28,6 +28,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				for idx, lhsExpr := range x.Lhs {
 					if typeAndValue, ok := pass.TypesInfo.Types[lhsExpr]; ok && typeAndValue.Type.String() == "error" {
 						if len(x.Rhs) == 1 {
+							// This is needed to extract the type name string a multi-value return type
 							if typeAndValue, ok := pass.TypesInfo.Types[x.Rhs[0]]; ok {
 								returnTypes := strings.Split(strings.Trim(typeAndValue.Type.String(), "()"), ", ")
 								if len(returnTypes) > idx && returnTypes[idx] == appErrorString {

--- a/errorVars/errorVars.go
+++ b/errorVars/errorVars.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package errorVars
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	appErrorString = "*github.com/mattermost/mattermost-server/v5/model.AppError"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "errorVars",
+	Doc:  "check for non valid type assignations to err and appErr prefixed variables",
+	Run:  run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch x := node.(type) {
+			case *ast.AssignStmt:
+				for idx, lhsExpr := range x.Lhs {
+					if typeAndValue, ok := pass.TypesInfo.Types[lhsExpr]; ok && typeAndValue.Type.String() == "error" {
+						if len(x.Rhs) == 1 {
+							if typeAndValue, ok := pass.TypesInfo.Types[x.Rhs[0]]; ok {
+								returnTypes := strings.Split(strings.Trim(typeAndValue.Type.String(), "()"), ", ")
+								if len(returnTypes) > idx && returnTypes[idx] == appErrorString {
+									pass.Reportf(x.Pos(), "assigning a *model.AppError to a `error` type variable, please create a new variable to store this value.")
+								}
+							}
+						} else if len(x.Rhs) == len(x.Lhs) {
+							if typeAndValue, ok := pass.TypesInfo.Types[x.Rhs[idx]]; ok && typeAndValue.Type.String() == appErrorString {
+								pass.Reportf(x.Pos(), "assigning a *model.AppError to a `error` type variable, please create a new variable to store this value.")
+							}
+						}
+					}
+				}
+				return true
+			}
+			return true
+		})
+	}
+	return nil, nil
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mattermost/mattermost-govet/emptyStrCmp"
 	"github.com/mattermost/mattermost-govet/equalLenAsserts"
 	"github.com/mattermost/mattermost-govet/errorAssertions"
+	"github.com/mattermost/mattermost-govet/errorVars"
 	"github.com/mattermost/mattermost-govet/immut"
 	"github.com/mattermost/mattermost-govet/inconsistentReceiverName"
 	"github.com/mattermost/mattermost-govet/license"
@@ -32,5 +33,6 @@ func main() {
 		emptyStrCmp.Analyzer,
 		configtelemetry.Analyzer,
 		errorAssertions.Analyzer,
+		errorVars.Analyzer,
 	)
 }


### PR DESCRIPTION
This prevents developers to accidentally assign `*model.AppError` values to `error` typed variables that were previously defined, for example:

```go
err := FunctionThatReturnsARegularError()
if err != nil {
    return err
}
err = FunctionThatReturnsAnAppError()
if err != nil {
    return err
}
```
That is now not allowed, because in the second call, you can have problems with the `!= nil` assertion because of this: https://golang.org/doc/faq#nil_error