### PR TITLE
Boundary check strCmp copy skip when file has no comments

### DIFF
--- a/emptyStrCmp/emptyStrCmp.go
+++ b/emptyStrCmp/emptyStrCmp.go
@@ -21,7 +21,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	const bindataHeader = "by go-bindata DO NOT EDIT. (@generated)"
 
 	for _, file := range pass.Files {
-		if strings.HasSuffix(file.Comments[0].List[0].Text, bindataHeader) {
+		if len(file.Comments) > 0 && strings.HasSuffix(file.Comments[0].List[0].Text, bindataHeader) {
 			continue
 		}
 


### PR DESCRIPTION
#### Summary
When doing an autogenerated file assessment, do it only for files that have comments

#### Ticket Link
N/A

