### PR TITLE
Implement check for mutex lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ This repository contains mattermost-specific go-vet rules that are used to maint
 1. **apiAuditLogs** - check that audit records are properly created in the API layer
 1. **rawSql** - check invalid usage of raw SQL queries instead of using the squirrel lib
 1. **emptyStrCmp** - check for idiomatic empty string comparisons
+1. **mutexLock** - check for cases where a mutex is left locked before returning

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-govet/immut"
 	"github.com/mattermost/mattermost-govet/inconsistentReceiverName"
 	"github.com/mattermost/mattermost-govet/license"
+	"github.com/mattermost/mattermost-govet/mutexLock"
 	"github.com/mattermost/mattermost-govet/openApiSync"
 	"github.com/mattermost/mattermost-govet/rawSql"
 	"github.com/mattermost/mattermost-govet/structuredLogging"
@@ -36,5 +37,6 @@ func main() {
 		errorAssertions.Analyzer,
 		errorVarsName.Analyzer,
 		errorVars.Analyzer,
+		mutexLock.Analyzer,
 	)
 }

--- a/mutexLock/mutexUnlock.go
+++ b/mutexLock/mutexUnlock.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mutexLock
+
+import (
+	"go/ast"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "mutexLock",
+	Doc:  "check for cases where a mutex is left locked before returning",
+	Run:  run,
+}
+
+func isMutex(varType string) bool {
+	switch varType {
+	case "sync.Mutex", "sync.RWMutex":
+		return true
+	}
+
+	return false
+}
+
+func isLock(methodName string) bool {
+	switch methodName {
+	case "Lock", "RLock":
+		return true
+	}
+
+	return false
+}
+
+func isUnlock(methodName string) bool {
+	switch methodName {
+	case "Unlock", "RUnlock":
+		return true
+	}
+
+	return false
+}
+
+type checkState struct {
+	lockPos   token.Pos
+	unlockPos token.Pos
+	counter   int
+	reported  bool
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		var m map[string]*checkState
+
+		check := func() {
+			for k, v := range m {
+				if v.counter > 0 {
+					if !v.reported {
+						pass.Reportf(v.lockPos, "possible return with mutex %s locked", k)
+						v.reported = true
+					}
+				}
+			}
+		}
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			if node == nil {
+				return false
+			}
+
+			if _, ok := node.(*ast.FuncDecl); ok {
+				check()
+				m = map[string]*checkState{}
+			}
+
+			if _, ok := node.(*ast.ReturnStmt); ok {
+				check()
+			}
+
+			if e, ok := node.(*ast.CallExpr); ok {
+				se, ok := e.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+
+				methodName := se.Sel.Name
+
+				var id *ast.Ident
+				switch e := se.X.(type) {
+				case *ast.SelectorExpr:
+					id = e.Sel
+				case *ast.Ident:
+					id = e
+				default:
+					return false
+				}
+
+				varName := id.Name
+				varType := pass.TypesInfo.Uses[id].Type().String()
+
+				if !isMutex(varType) {
+					return false
+				}
+
+				st := m[varName]
+				if st == nil {
+					st = &checkState{}
+				}
+
+				if isLock(methodName) {
+					st.lockPos = se.Pos()
+					st.counter++
+				} else if isUnlock(methodName) {
+					st.unlockPos = se.Pos()
+					st.counter--
+				}
+
+				m[varName] = st
+
+				return false
+			}
+
+			return true
+		})
+
+		check()
+
+	}
+	return nil, nil
+}

--- a/mutexLock/mutexUnlock_test.go
+++ b/mutexLock/mutexUnlock_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package mutexLock
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "app")
+}

--- a/mutexLock/testdata/src/app/mutex.go
+++ b/mutexLock/testdata/src/app/mutex.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"sync"
+)
+
+func func1() {
+	var m sync.Mutex
+	m.Lock() // want `possible return with mutex m locked`
+	if true {
+		return
+	}
+	m.Unlock()
+}
+
+func func2() {
+	var m sync.Mutex
+	m.Lock()
+	if true {
+	}
+	m.Unlock()
+}
+
+func func3() {
+	var m sync.Mutex
+	m.Lock() // want `possible return with mutex m locked`
+}
+
+func func4() {
+	var m sync.Mutex
+	m.Lock()
+	defer m.Unlock()
+}
+
+func func5() {
+	var m sync.Mutex
+	m.Lock() // want `possible return with mutex m locked`
+	if true {
+		return
+	}
+	if true {
+		return
+	}
+}
+
+func func6() {
+	var m sync.Mutex
+	if true {
+		m.Lock()
+		m.Unlock()
+	}
+}
+
+type testStruct struct {
+	m sync.Mutex
+}
+
+func func7() {
+	var s testStruct
+	s.m.Lock() // want `possible return with mutex m locked`
+	if true {
+		return
+	}
+	s.m.Unlock()
+}
+
+func func8() {
+	var m sync.Mutex
+
+	m.Lock()
+	defer func() {
+		m.Unlock()
+	}()
+
+	if true {
+		return
+	}
+}
+
+func func9() {
+	var m sync.Mutex
+	m.Lock()
+	if true {
+		m.Unlock()
+		return
+	}
+	m.Unlock()
+}
+
+func func10() {
+	var m sync.Mutex
+	var n sync.Mutex
+
+	m.Lock() // want `possible return with mutex m locked`
+	n.Unlock()
+}


### PR DESCRIPTION
#### Summary

Honestly I still can't believe I missed this kind of bug during review but since it happened I was curious to explore an automated way to help. Spent part of my OSF writing this simple check which should cover most basic cases. 

Interestingly it didn't spot anything in our server repository. Did also test it on a commit prior to the fix:

```
github.com/mattermost/mattermost-server » go vet -vettool=../mattermost-govet/main -mutexLock ./enterprise/...
# github.com/mattermost/mattermost-server/v5/enterprise/cluster
enterprise/cluster/gossip_client_cluster_stats.go:92:2: possible return with mutex requestMut locked
enterprise/cluster/gossip_client_config.go:92:2: possible return with mutex requestMut locked
enterprise/cluster/gossip_client_logs.go:98:2: possible return with mutex requestMut locked
enterprise/cluster/gossip_client_plugin_status.go:98:2: possible return with mutex requestMut locked
```