### PR TITLE
Fix ignore files

### DIFF
--- a/inconsistentReceiverName/inconsistentReceiverName.go
+++ b/inconsistentReceiverName/inconsistentReceiverName.go
@@ -29,7 +29,10 @@ func init() {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	ignoreFiles := strings.Split(ignoreFilesPattern, ",")
+	var ignoreFiles []string
+	if ignoreFilesPattern != "" {
+		ignoreFiles = strings.Split(ignoreFilesPattern, ",")
+	}
 
 	firstReceiverNameForType := make(map[string]firstReceiverName)
 	for _, file := range pass.Files {

--- a/pointerToSlice/pointerToSlice.go
+++ b/pointerToSlice/pointerToSlice.go
@@ -24,7 +24,10 @@ func init() {
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	ignoreFiles := strings.Split(ignoreFilesPattern, ",")
+	var ignoreFiles []string
+	if ignoreFilesPattern != "" {
+		ignoreFiles = strings.Split(ignoreFilesPattern, ",")
+	}
 
 	checkNode := func(expr ast.Expr) {
 		sexpr, ok := expr.(*ast.StarExpr)


### PR DESCRIPTION
#### Summary

Turns out that  if you don't pass any file to ignore then it results into ignoring everything. This is due to this specific behaviour of `strings.Split()`:

> func Split(s, sep string) []string
> If s does not contain sep and sep is not empty, Split returns a slice of length 1 whose only element is s.

So an empty string was getting in `ignoreFiles` which would make the later `strings.HasSuffix()` check always return true.

This was accidentally caught by running some tests locally. I think we should consider setting up some CI automation. I can make a dedicated ticket.