### PR TITLE
[MM-46238] Implemented vet check for errors being passed as details in NewAppError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   test:
     docker:
-      - image: cimg/go:1.17-node
+      - image: cimg/go:1.19-node
     working_directory: ~/mattermost-govet
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ This repository contains mattermost-specific go-vet rules that are used to maint
 1. **emptyStrCmp** - check for idiomatic empty string comparisons
 1. **pointerToSlice** - check for usage of pointer to slice in function definitions
 1. **mutexLock** - check for cases where a mutex is left locked before returning
+1. **wrapError** - check for original errors being passed as details rather then wrapped

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package main
 
 import (
@@ -17,6 +20,7 @@ import (
 	"github.com/mattermost/mattermost-govet/v2/rawSql"
 	"github.com/mattermost/mattermost-govet/v2/structuredLogging"
 	"github.com/mattermost/mattermost-govet/v2/tFatal"
+	"github.com/mattermost/mattermost-govet/v2/wraperrors"
 	"golang.org/x/tools/go/analysis/unitchecker"
 )
 
@@ -40,5 +44,6 @@ func main() {
 		errorVars.Analyzer,
 		pointerToSlice.Analyzer,
 		mutexLock.Analyzer,
+		wraperrors.Analyzer,
 	)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package util
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+func FunctionName(expr *ast.CallExpr) (string, string, bool) {
+	switch t := expr.Fun.(type) {
+	case *ast.SelectorExpr:
+		receiver, ok := t.X.(*ast.Ident)
+		if !ok {
+			return "", "", false
+		}
+
+		return receiver.Name, t.Sel.Name, true
+
+	case *ast.Ident:
+		return "", t.Name, true
+	}
+
+	return "", "", false
+}
+
+func CheckReturnType(pass *analysis.Pass, expr ast.Expr, sample string) int {
+	sample = strings.TrimSpace(sample)
+
+	typ, ok := pass.TypesInfo.Types[expr]
+	if !ok {
+		return -1
+	}
+
+	list := typ.Type.String()
+	list = strings.Trim(list, "()")
+	parts := strings.Split(list, ",")
+	for i, part := range parts {
+		if sample == strings.TrimSpace(part) {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/wraperrors/testdata/src/model/model.go
+++ b/wraperrors/testdata/src/model/model.go
@@ -1,0 +1,11 @@
+package model
+
+func NewAppError(where string, id string, params map[string]any, details string, status int) *AppError {
+	return &AppError{}
+}
+
+type AppError struct{}
+
+func (a *AppError) Wrap(err error) *AppError {
+	return a
+}

--- a/wraperrors/testdata/src/wraperrors/wraperrors.go
+++ b/wraperrors/testdata/src/wraperrors/wraperrors.go
@@ -1,0 +1,19 @@
+package wraperrors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"model"
+)
+
+func dosomething() {
+	err := errors.New("test")
+	appErr := model.NewAppError("SetJobError", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError) // want `Don't use the details field to report the original error, call model\.NewAppError\(\.\.\.\)\.Wrap\(err\) instead`
+	fmt.Println(appErr)
+	appErr = model.NewAppError("SetJobError", "app.job.update.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	fmt.Println(appErr)
+	appErr = model.NewAppError("SetJobError", "app.job.update.app_error", nil, "something else", http.StatusInternalServerError)
+	fmt.Println(appErr)
+}

--- a/wraperrors/wraperr.go
+++ b/wraperrors/wraperr.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package wraperrors
+
+import (
+	"fmt"
+	"go/ast"
+
+	"github.com/mattermost/mattermost-govet/v2/util"
+	"golang.org/x/tools/go/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "wrapError",
+	Doc:  "check for errors that are being passed in the details field of model.AppError",
+	Run:  run,
+}
+
+var appErrorType = "*github.com/mattermost/mattermost-server/v6/model.AppError"
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			// Skip empty or non-CallExpr nodes
+			if node == nil {
+				return true
+			}
+
+			callExpr, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			_, function, ok := util.FunctionName(callExpr)
+			if !ok || function != "NewAppError" {
+				return true
+			}
+			if util.CheckReturnType(pass, callExpr, appErrorType) < 0 {
+				return true
+			}
+
+			// make sure there are enough arguments
+			if len(callExpr.Args) <= 4 {
+				return true
+			}
+
+			// check the fourth argument (details)
+			errorCall, ok := callExpr.Args[3].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			receiver, function, ok := util.FunctionName(errorCall)
+			if !ok || function != "Error" {
+				return true
+			}
+
+			msg := fmt.Sprintf("Don't use the details field to report the original error, call model.NewAppError(...).Wrap(%s) instead", receiver)
+			pass.Report(analysis.Diagnostic{
+				Pos:     node.Pos(),
+				End:     node.End(),
+				Message: msg,
+				SuggestedFixes: []analysis.SuggestedFix{
+					{
+						Message: "Pass the error via .Wrap(...)",
+						TextEdits: []analysis.TextEdit{
+							{
+								Pos:     errorCall.Pos(),
+								End:     errorCall.End(),
+								NewText: []byte("\"\""),
+							},
+							{
+								Pos:     callExpr.Rparen,
+								End:     callExpr.Rparen,
+								NewText: []byte(fmt.Sprintf(".Wrap(%s)", receiver)),
+							},
+						},
+					},
+				},
+			})
+
+			return true
+		})
+	}
+
+	return nil, nil
+}

--- a/wraperrors/wraperr_test.go
+++ b/wraperrors/wraperr_test.go
@@ -1,0 +1,13 @@
+package wraperrors
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func Test(t *testing.T) {
+	appErrorType = "*model.AppError"
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, Analyzer, "model", "wraperrors")
+}


### PR DESCRIPTION
#### Summary
With the introduction of `(*model.AppError).Wrap(err)` we added a structured way to propagate the original error to the caller. This PR adds a vet check for errors being passed in the `details` of `NewAppError`.

#### Ticket Link
[MM-46238](https://mattermost.atlassian.net/browse/MM-46238)