### PR TITLE
Fix OpenAPI sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Checkout mattermost-api-reference
+          name: Checkout mattermost
           command: |
             pushd ../
-            git clone --depth=1 https://github.com/mattermost/mattermost-api-reference.git
-            pushd mattermost-api-reference
+            git clone --depth=1 https://github.com/mattermost/mattermost.git
+            pushd mattermost/api
             make build
             popd
             popd

--- a/openApiSync/openApiSync.go
+++ b/openApiSync/openApiSync.go
@@ -97,7 +97,6 @@ func processRouterInit(pass *analysis.Pass, names []string, routerPrefixes map[s
 				if stringInSlice(handler, IgnoredCases, true) { // ignore special cases
 					continue
 				}
-				handler = strings.TrimPrefix(handler, "api/v4")
 				if !strings.HasPrefix(handler, "/") {
 					handler = "/" + handler
 				}

--- a/openApiSync/openApiSync.go
+++ b/openApiSync/openApiSync.go
@@ -169,7 +169,7 @@ func parseInitFunction(pass *analysis.Pass, decl *ast.FuncDecl, routerPrefixes m
 				continue
 			}
 			subRouterName := formatNode(pass.Fset, node.Lhs[0])[15:]
-			if subRouterName == "ApiRoot" || subRouterName == "Root" {
+			if subRouterName == "APIRoot" || subRouterName == "APIRoot5" || subRouterName == "Root" {
 				continue
 			}
 
@@ -178,7 +178,7 @@ func parseInitFunction(pass *analysis.Pass, decl *ast.FuncDecl, routerPrefixes m
 			path := rhs[strings.Index(rhs, ".")+13 : strings.LastIndex(rhs, ".")-2]
 			prefix := ""
 			switch router {
-			case "ApiRoot":
+			case "APIRoot":
 				prefix = "api/v4"
 			case "Root":
 				prefix = ""

--- a/openApiSync/openApiSync_test.go
+++ b/openApiSync/openApiSync_test.go
@@ -13,6 +13,6 @@ import (
 func Test(t *testing.T) {
 	rand.Seed(1)
 	testdata := analysistest.TestData()
-	specFile = "../../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml"
+	specFile = "../../mattermost/api/v4/html/static/mattermost-openapi-v4.yaml"
 	analysistest.Run(t, testdata, Analyzer, "api")
 }

--- a/openApiSync/testdata/src/api/api.go
+++ b/openApiSync/testdata/src/api/api.go
@@ -12,7 +12,7 @@ import (
 
 type Routes struct {
 	Root    *mux.Router // ''
-	ApiRoot *mux.Router // 'api/v4'
+	APIRoot *mux.Router // 'api/v4'
 
 	Users  *mux.Router // 'api/v4/userzs'
 	Groups *mux.Router // 'api/v4/groups'
@@ -30,10 +30,10 @@ func Init(root *mux.Router) *API {
 		BaseRoutes: &Routes{},
 	}
 	api.BaseRoutes.Root = root
-	api.BaseRoutes.ApiRoot = root.PathPrefix("api/v4").Subrouter()
+	api.BaseRoutes.APIRoot = root.PathPrefix("api/v4").Subrouter()
 
-	api.BaseRoutes.Users = api.BaseRoutes.ApiRoot.PathPrefix("/users").Subrouter()   // want "PathPrefix doesn't match field comment for field 'Users': 'api/v4/users' vs 'api/v4/userzs'"
-	api.BaseRoutes.Groups = api.BaseRoutes.ApiRoot.PathPrefix("/gruops").Subrouter() // want "PathPrefix doesn't match field comment for field 'Groups': 'api/v4/gruops' vs 'api/v4/groups'"
+	api.BaseRoutes.Users = api.BaseRoutes.APIRoot.PathPrefix("/users").Subrouter()   // want "PathPrefix doesn't match field comment for field 'Users': 'api/v4/users' vs 'api/v4/userzs'"
+	api.BaseRoutes.Groups = api.BaseRoutes.APIRoot.PathPrefix("/gruops").Subrouter() // want "PathPrefix doesn't match field comment for field 'Groups': 'api/v4/gruops' vs 'api/v4/groups'"
 	api.InitUsers()
 	return api
 }

--- a/openApiSync/testdata/src/api/users.go
+++ b/openApiSync/testdata/src/api/users.go
@@ -9,8 +9,8 @@ import (
 )
 
 func (a *API) InitUsers() {
-	a.BaseRoutes.Users.Handle("/ids", a.ApiSessionRequired(getUsersByIds)).Methods("POST")                                                                                     // want `Cannot find /userzs/ids method: POST in OpenAPI 3 spec. \(maybe you meant: \[/users/ids\]\)`
-	a.BaseRoutes.Groups.Handle("/{group_id:[A-Za-z0-9]+}/{syncable_type:teams|channelz}/{syncable_id:[A-Za-z0-9]+}/link", a.ApiSessionRequired(getUsersByIds)).Methods("POST") // want `Cannot find /groups/{group_id}/channelz/{syncable_id}/link method: POST in OpenAPI 3 spec.`
+	a.BaseRoutes.Users.Handle("/ids", a.ApiSessionRequired(getUsersByIds)).Methods("POST")                                                                                     // want `Cannot find /api/v4/userzs/ids method: POST in OpenAPI 3 spec. \(maybe you meant: \[/api/v4/users/ids\]\)`
+	a.BaseRoutes.Groups.Handle("/{group_id:[A-Za-z0-9]+}/{syncable_type:teams|channelz}/{syncable_id:[A-Za-z0-9]+}/link", a.ApiSessionRequired(getUsersByIds)).Methods("POST") // want `Cannot find /api/v4/groups/{group_id}/channelz/{syncable_id}/link method: POST in OpenAPI 3 spec.`
 
 }
 func getUsersByIds(c *context.Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary
See https://github.com/mattermost/mattermost/pull/23974, but in short this PR fixes issues running the OpenAPI vetting tool against the current monorepo.

#### Ticket Link
None.