### PR TITLE
License allow multiple build headers

### DIFF
--- a/license/license_test.go
+++ b/license/license_test.go
@@ -111,6 +111,11 @@ func TestLicense(t *testing.T) {
 					testdata := analysistest.TestData()
 					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "build/withoutnewline"))
 				})
+
+				t.Run("multiple build directives with valid license", func(t *testing.T) {
+					testdata := analysistest.TestData()
+					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "build/multipledirectives"))
+				})
 			})
 		})
 	}

--- a/license/license_test.go
+++ b/license/license_test.go
@@ -31,7 +31,7 @@ func TestLicense(t *testing.T) {
 			license.EEAnalyzer,
 		},
 		{
-			"Standard",
+			"Source Available",
 			"source_available/enterprise",
 			license.Analyzer,
 		},

--- a/license/testdata/src/enterprise/build/multipledirectives/build.go
+++ b/license/testdata/src/enterprise/build/multipledirectives/build.go
@@ -1,0 +1,9 @@
+//go:generate echo "command1"
+//go:generate echo "command2"
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See ENTERPRISE-LICENSE.txt and SOURCE-CODE-LICENSE.txt for license information.
+
+package multipledirectives
+
+func Build() {}

--- a/license/testdata/src/source_available/enterprise/build/multipledirectives/build.go
+++ b/license/testdata/src/source_available/enterprise/build/multipledirectives/build.go
@@ -1,0 +1,9 @@
+//go:generate echo "command1"
+//go:generate echo "command2"
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package multipledirectives
+
+func Build() {}

--- a/license/testdata/src/standard/build/multipledirectives/build.go
+++ b/license/testdata/src/standard/build/multipledirectives/build.go
@@ -1,0 +1,9 @@
+//go:generate echo "command1"
+//go:generate echo "command2"
+
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package multipledirectives
+
+func Build() {}


### PR DESCRIPTION
#### Summary
Some plugins rely on multiple `go:generate` directives, but our existing license checks didn't account for that in enforcing the copyright header, e.g.:

```go
//go:generate mockery --name=Client
//go:generate go run layer_generators/main.go

// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
// See LICENSE.txt for license information.
package msteams
```

#### Ticket Link
None