### PR TITLE
Add optional `-license.year` flag

### DIFF
--- a/license/license.go
+++ b/license/license.go
@@ -26,6 +26,8 @@ var EEAnalyzer = &analysis.Analyzer{
 	Run:  run,
 }
 
+const defaultLicenseYear = 2015
+
 var (
 	ignoreFilesPattern       string
 	licenseYear              string
@@ -67,14 +69,14 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// Validate license year
-	year := 2015
+	year := defaultLicenseYear
 	if licenseYear != "" {
 		if y, err := strconv.Atoi(licenseYear); err != nil {
 			return nil, fmt.Errorf("invalid license year: %v", err)
 		} else {
 			currentYear := time.Now().Year()
-			if y < 2015 || y > currentYear {
-				return nil, fmt.Errorf("license year must be between 2015 and %d", currentYear)
+			if y < defaultLicenseYear || y > currentYear {
+				return nil, fmt.Errorf("license year must be between %d and %d", defaultLicenseYear, currentYear)
 			}
 			year = y
 		}

--- a/license/license.go
+++ b/license/license.go
@@ -4,9 +4,12 @@
 package license
 
 import (
+	"fmt"
 	"go/ast"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/tools/go/analysis"
 )
@@ -25,11 +28,12 @@ var EEAnalyzer = &analysis.Analyzer{
 
 var (
 	ignoreFilesPattern       string
+	licenseYear              string
 	sourceAvailablePackageRe = regexp.MustCompile("/enterprise")
 )
 
 const (
-	defaultLicenseLine1         = "// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved."
+	licenseLine1Format          = "// Copyright (c) %d-present Mattermost, Inc. All Rights Reserved."
 	defaultLicenseLine2         = "// See LICENSE.txt for license information."
 	enterpriseLicenseLine2      = "// See ENTERPRISE-LICENSE.txt and SOURCE-CODE-LICENSE.txt for license information."
 	sourceAvailableLicenseLine2 = "// See LICENSE.enterprise for license information."
@@ -51,7 +55,9 @@ var generatedHeaders = []string{
 
 func init() {
 	Analyzer.Flags.StringVar(&ignoreFilesPattern, "ignore", "", "Comma separated list of files to ignore")
+	Analyzer.Flags.StringVar(&licenseYear, "year", "2015", "Year to use in license header (2015-present)")
 	EEAnalyzer.Flags.StringVar(&ignoreFilesPattern, "ignore", "", "Comma separated list of files to ignore")
+	EEAnalyzer.Flags.StringVar(&licenseYear, "year", "2015", "Year to use in license header (2015-present)")
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -60,7 +66,21 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		ignoreFiles = strings.Split(ignoreFilesPattern, ",")
 	}
 
-	expectedLine1 := defaultLicenseLine1
+	// Validate license year
+	year := 2015
+	if licenseYear != "" {
+		if y, err := strconv.Atoi(licenseYear); err != nil {
+			return nil, fmt.Errorf("invalid license year: %v", err)
+		} else {
+			currentYear := time.Now().Year()
+			if y < 2015 || y > currentYear {
+				return nil, fmt.Errorf("license year must be between 2015 and %d", currentYear)
+			}
+			year = y
+		}
+	}
+
+	expectedLine1 := fmt.Sprintf(licenseLine1Format, year)
 	expectedLine2 := defaultLicenseLine2
 
 	if pass.Analyzer.Name == "enterpriseLicense" {

--- a/license/license.go
+++ b/license/license.go
@@ -72,11 +72,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	year := defaultLicenseYear
 	if licenseYear != "" {
 		if y, err := strconv.Atoi(licenseYear); err != nil {
-			return nil, fmt.Errorf("invalid license year: %v", err)
+			return nil, fmt.Errorf("invalid license year: %w", err)
 		} else {
 			currentYear := time.Now().Year()
 			if y < defaultLicenseYear || y > currentYear {
-				return nil, fmt.Errorf("license year must be between %d and %d", defaultLicenseYear, currentYear)
+				return nil, fmt.Errorf("license year must be between %d and %d: %w", defaultLicenseYear, currentYear, err)
 			}
 			year = y
 		}

--- a/license/license.go
+++ b/license/license.go
@@ -68,6 +68,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// Validate license year
+	if licenseYear == 0 {
+		licenseYear = defaultLicenseYear
+	}
+
 	currentYear := time.Now().Year()
 	if licenseYear < defaultLicenseYear || licenseYear > currentYear {
 		return nil, fmt.Errorf("license year must be between %d and %d", defaultLicenseYear, currentYear)

--- a/license/license_test.go
+++ b/license/license_test.go
@@ -104,15 +104,15 @@ func TestLicense(t *testing.T) {
 				t.Run("invalid year", func(t *testing.T) {
 					mt := &MockT{}
 					testdata := analysistest.TestData()
-					require.NoError(t, testCase.Analyzer.Flags.Set("year", "invalid"))
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "-1"))
 					t.Cleanup(func() {
-						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", "0"))
 					})
 					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
 
 					require.Len(t, mt.calls, 1)
 					for _, call := range mt.calls {
-						require.Contains(t, call, "invalid license year:")
+						require.Contains(t, call, "license year must be between 2015 and")
 					}
 				})
 
@@ -121,7 +121,7 @@ func TestLicense(t *testing.T) {
 					testdata := analysistest.TestData()
 					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2014"))
 					t.Cleanup(func() {
-						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", "0"))
 					})
 					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
 
@@ -141,7 +141,7 @@ func TestLicense(t *testing.T) {
 					testdata := analysistest.TestData()
 					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2024"))
 					t.Cleanup(func() {
-						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", "0"))
 					})
 					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "parameterized_year/2024"))
 				})
@@ -150,7 +150,7 @@ func TestLicense(t *testing.T) {
 					testdata := analysistest.TestData()
 					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2025"))
 					t.Cleanup(func() {
-						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", "0"))
 					})
 					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "parameterized_year/current"))
 				})
@@ -160,7 +160,7 @@ func TestLicense(t *testing.T) {
 					testdata := analysistest.TestData()
 					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2026"))
 					t.Cleanup(func() {
-						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", "0"))
 					})
 					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
 

--- a/license/license_test.go
+++ b/license/license_test.go
@@ -4,6 +4,7 @@
 package license_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -13,6 +14,14 @@ import (
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
+
+type MockT struct {
+	calls []string
+}
+
+func (mt *MockT) Errorf(format string, args ...interface{}) {
+	mt.calls = append(mt.calls, fmt.Sprintf(format, args...))
+}
 
 func TestLicense(t *testing.T) {
 	testCases := []struct {
@@ -89,6 +98,77 @@ func TestLicense(t *testing.T) {
 			t.Run("invalid reference on line 2", func(t *testing.T) {
 				testdata := analysistest.TestData()
 				analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "invalid_reference"))
+			})
+
+			t.Run("parameterized year", func(t *testing.T) {
+				t.Run("invalid year", func(t *testing.T) {
+					mt := &MockT{}
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "invalid"))
+					t.Cleanup(func() {
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+					})
+					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
+
+					require.Len(t, mt.calls, 1)
+					for _, call := range mt.calls {
+						require.Contains(t, call, "invalid license year:")
+					}
+				})
+
+				t.Run("before 2015", func(t *testing.T) {
+					mt := &MockT{}
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2014"))
+					t.Cleanup(func() {
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+					})
+					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
+
+					require.Len(t, mt.calls, 1)
+					for _, call := range mt.calls {
+						require.Contains(t, call, "license year must be between 2015 and")
+					}
+				})
+
+				t.Run("2015", func(t *testing.T) {
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2015"))
+					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "parameterized_year/2015"))
+				})
+
+				t.Run("2024", func(t *testing.T) {
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2024"))
+					t.Cleanup(func() {
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+					})
+					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "parameterized_year/2024"))
+				})
+
+				t.Run("current year", func(t *testing.T) {
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2025"))
+					t.Cleanup(func() {
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+					})
+					analysistest.Run(t, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "parameterized_year/current"))
+				})
+
+				t.Run("future year", func(t *testing.T) {
+					mt := &MockT{}
+					testdata := analysistest.TestData()
+					require.NoError(t, testCase.Analyzer.Flags.Set("year", "2026"))
+					t.Cleanup(func() {
+						require.NoError(t, testCase.Analyzer.Flags.Set("year", ""))
+					})
+					analysistest.Run(mt, testdata, testCase.Analyzer, filepath.Join(testCase.Path, "valid"))
+
+					require.Len(t, mt.calls, 1)
+					for _, call := range mt.calls {
+						require.Contains(t, call, "license year must be between 2015 and")
+					}
+				})
 			})
 
 			t.Run("build directives", func(t *testing.T) {

--- a/license/testdata/src/enterprise/parameterized_year/2015/test.go
+++ b/license/testdata/src/enterprise/parameterized_year/2015/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See ENTERPRISE-LICENSE.txt and SOURCE-CODE-LICENSE.txt for license information.
+
+package year2015
+
+func Test() {}

--- a/license/testdata/src/enterprise/parameterized_year/2024/test.go
+++ b/license/testdata/src/enterprise/parameterized_year/2024/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024-present Mattermost, Inc. All Rights Reserved.
+// See ENTERPRISE-LICENSE.txt and SOURCE-CODE-LICENSE.txt for license information.
+
+package year2024
+
+func Test() {}

--- a/license/testdata/src/enterprise/parameterized_year/current/test.go
+++ b/license/testdata/src/enterprise/parameterized_year/current/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-present Mattermost, Inc. All Rights Reserved.
+// See ENTERPRISE-LICENSE.txt and SOURCE-CODE-LICENSE.txt for license information.
+
+package yearcurrent
+
+func Test() {}

--- a/license/testdata/src/source_available/enterprise/parameterized_year/2015/test.go
+++ b/license/testdata/src/source_available/enterprise/parameterized_year/2015/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package year2015
+
+func Test() {}

--- a/license/testdata/src/source_available/enterprise/parameterized_year/2024/test.go
+++ b/license/testdata/src/source_available/enterprise/parameterized_year/2024/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package year2024
+
+func Test() {}

--- a/license/testdata/src/source_available/enterprise/parameterized_year/current/test.go
+++ b/license/testdata/src/source_available/enterprise/parameterized_year/current/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package yearcurrent
+
+func Test() {}

--- a/license/testdata/src/standard/parameterized_year/2015/test.go
+++ b/license/testdata/src/standard/parameterized_year/2015/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package year2015
+
+func Test() {}

--- a/license/testdata/src/standard/parameterized_year/2024/test.go
+++ b/license/testdata/src/standard/parameterized_year/2024/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2024-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package year2024
+
+func Test() {}

--- a/license/testdata/src/standard/parameterized_year/current/test.go
+++ b/license/testdata/src/standard/parameterized_year/current/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package yearcurrent
+
+func Test() {}


### PR DESCRIPTION
#### Summary
Allow repositories to configure the start date of their Copyright claims, e.g.

```sh
$(GO) vet -vettool=$(GOBIN)/mattermost-govet -license -license.year=2020 ./server/...
```

requires

```go
// Copyright (c) 2020-present Mattermost, Inc. All Rights Reserved.
// See LICENSE.txt for license information.
```

#### Ticket Link
None