### PR TITLE
ignore COUNT(*) patterns in SELECT * vet check

### DIFF
--- a/noSelectStar/noSelectStar.go
+++ b/noSelectStar/noSelectStar.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-var selectStarRegex = regexp.MustCompile(`(?i)SELECT\s+\*`)
+var selectStarRegex = regexp.MustCompile(`(?i)SELECT\s+(.+\.)?\*`)
 
 // replaceCountStar replaces COUNT(*) patterns with COUNT() to avoid false positives
 func replaceCountStar(s string) string {

--- a/noSelectStar/testdata/src/a/a.go
+++ b/noSelectStar/testdata/src/a/a.go
@@ -12,6 +12,8 @@ func example() {
 	// These should trigger warnings
 	_ = "SELECT * FROM users" // want `do not use SELECT \*: explicitly select the needed columns instead`
 	_ = "select * from table" // want `do not use SELECT \*: explicitly select the needed columns instead`
+	_ = "SELECT a.* FROM users a" // want `do not use SELECT \*: explicitly select the needed columns instead`
+	_ = "SELECT users.* FROM users" // want `do not use SELECT \*: explicitly select the needed columns instead`
 
 	// These should not trigger warnings
 	_ = "SELECT id, name FROM users"
@@ -44,6 +46,10 @@ func example() {
 	s.getBuilder().Select("*", "count(*)").From("Channels")                                                              // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select().Column("count(*)").Column("*").From("Channels")                                              // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select().Columns("count(*)", "*").From("Channels")                                                    // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select("c.*").From("Channels c")                                                                      // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select("Channels.*").From("Channels")                                                                 // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select().Column("c.*").From("Channels c")                                                             // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select().Columns("Channels.*").From("Channels")                                                       // want `do not use SELECT \*: explicitly select the needed columns instead`
 
 	// These should not trigger warnings for Select function
 	s.getBuilder().Select("").From("Channels").Where(sq.Eq{"Id": "id"})

--- a/noSelectStar/testdata/src/a/a.go
+++ b/noSelectStar/testdata/src/a/a.go
@@ -17,10 +17,18 @@ func example() {
 	_ = "SELECT id, name FROM users"
 	_ = "Just a * by itself"
 	_ = "SELECT"
+	_ = "SELECT COUNT(*) FROM users"
+	_ = "SELECT COUNT( * ) FROM users"
+	_ = "SELECT id, COUNT(*) FROM users GROUP BY id"
+	_ = "SELECT Count(*) FROM users"
+	_ = "SELECT COUNT(*) FROM users WHERE name LIKE '%*%'"
+	_ = "SELECT coUNt(*) FROM users"
+	_ = "SELECT id, CoUnT(*) FROM users GROUP BY id"
 
 	// These should trigger warnings for Select function
 	var s store
 	s.getBuilder().Select("*").From("Channels").Where(sq.Eq{"Id": "id"})                                                 // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select("Id", "*").From("Channels")                                                                    // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select("id", "*").From("Channels").Where(sq.Eq{"Id": "id"})                                           // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select("id", "*", "name").From("Channels").Where(sq.Eq{"Id": "id"})                                   // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select("id", "name", "*").From("Channels").Where(sq.Eq{"Id": "id"})                                   // want `do not use SELECT \*: explicitly select the needed columns instead`
@@ -33,6 +41,9 @@ func example() {
 	s.getBuilder().Select().Columns("id", "*", "name").From("Channels").Where(sq.Eq{"Id": "id"})                         // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select().Columns("id", "name", "*").From("Channels").Where(sq.Eq{"Id": "id"})                         // want `do not use SELECT \*: explicitly select the needed columns instead`
 	s.getBuilder().Select("id", "name").From("Channels").Where(sq.Eq{"Id": s.getBuilder().Select("*").From("ValidIds")}) // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select("*", "count(*)").From("Channels")                                                              // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select().Column("count(*)").Column("*").From("Channels")                                              // want `do not use SELECT \*: explicitly select the needed columns instead`
+	s.getBuilder().Select().Columns("count(*)", "*").From("Channels")                                                    // want `do not use SELECT \*: explicitly select the needed columns instead`
 
 	// These should not trigger warnings for Select function
 	s.getBuilder().Select("").From("Channels").Where(sq.Eq{"Id": "id"})
@@ -44,6 +55,15 @@ func example() {
 	s.getBuilder().Select().Columns("").From("Channels").Where(sq.Eq{"Id": "id"})
 	s.getBuilder().Select().Columns("id").From("Channels").Where(sq.Eq{"Id": "id"})
 	s.getBuilder().Select().Columns("id", "name").From("Channels").Where(sq.Eq{"Id": "id"})
-	s.getBuilder().Select().Columns("id", "name").From("Channels").Where(sq.Eq{"Id": "id"})
 	s.getBuilder().Select("id", "name").From("Channels").Where(sq.Eq{"Id": s.getBuilder().Select("Id").From("ValidIds")})
+	s.getBuilder().Select("COUNT(*)").From("Channels")
+	s.getBuilder().Select("COUNT( * )").From("Channels")
+	s.getBuilder().Select("id", "COUNT(*)").From("Channels")
+	s.getBuilder().Select().Column("COUNT(*)").From("Channels")
+	s.getBuilder().Select().Columns("id", "COUNT(*)").From("Channels")
+	s.getBuilder().Select("Count(*)").From("Channels")
+	s.getBuilder().Select("coUNt( * )").From("Channels")
+	s.getBuilder().Select("id", "CoUnT(*)").From("Channels")
+	s.getBuilder().Select().Column("cOuNt(*)").From("Channels")
+	s.getBuilder().Select().Columns("id", "COunt(*)").From("Channels")
 }


### PR DESCRIPTION
#### Summary
As we get closer to enforcing no `SELECT *`, I realized that `SELECT COUNT(*)` and the like should be ignored. This updates the vet tool as such with the simple heuristic of first replacing `COUNT(*)` with `COUNT()` and then keeping the existing scan.

Secondly, it addresses cases like `SELECT a.*` (thanks @isacikgoz for catching this in review!).

#### Ticket Link
None