### PR TITLE
Bump golang version to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-    go-version: "1.24.6"
+    go-version: "1.25.8"
 
 jobs:
     check-golangci-lint:
@@ -20,9 +20,9 @@ jobs:
             with:
               go-version: ${{ env.go-version }}
           - name: Run golangci-lint
-            uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
+            uses: golangci/golangci-lint-action@7119f3d5ddced62a10a044847a6c6bb0f7a5e76a # v7.0.0
             with:
-              version: v1.64.7
+              version: v2.6.0
 
     build:
         name: Build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+version: "2"
+
+issues:
+  excludes:
+    - path: immut/testdata.go
+      linters:
+        - govet
+      text: "buildtag"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,9 @@
 version: "2"
 
-issues:
-  excludes:
-    - path: immut/testdata.go
-      linters:
-        - govet
-      text: "buildtag"
+linters:
+  exclusions:
+    rules:
+      - path: immut/testdata.go
+        linters:
+          - govet
+        text: "buildtag"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-govet/v2
 
-go 1.24.6
+go 1.25.8
 
 require (
 	github.com/getkin/kin-openapi v0.133.0

--- a/immut/testdata.go
+++ b/immut/testdata.go
@@ -1,5 +1,6 @@
 //go:build ignore
 
+//nolint:govet
 package pkg
 
 //immut:type T

--- a/immut/testdata.go
+++ b/immut/testdata.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package pkg
 

--- a/immut/testdata.go
+++ b/immut/testdata.go
@@ -1,6 +1,5 @@
 //go:build ignore
 
-//nolint:govet
 package pkg
 
 //immut:type T

--- a/openApiSync/openApiSync.go
+++ b/openApiSync/openApiSync.go
@@ -38,9 +38,9 @@ func init() {
 }
 
 // formatNode converts AST node to string
-func formatNode(fset *token.FileSet, node interface{}) string {
+func formatNode(fset *token.FileSet, node any) string {
 	var typeNameBuf bytes.Buffer
-	printer.Fprint(&typeNameBuf, fset, node)
+	_ = printer.Fprint(&typeNameBuf, fset, node)
 	return typeNameBuf.String()
 }
 
@@ -59,7 +59,7 @@ func stringInSlice(str string, slice []string, partial bool) bool {
 
 // cleanRegexp removes parts of URL path regexp to be compatible with OpenAPI paths
 func cleanRegexp(s string) string {
-	return strings.Replace(s, ":[A-Za-z0-9]+", "", -1)
+	return strings.ReplaceAll(s, ":[A-Za-z0-9]+", "")
 }
 
 // splitHandlerByGroup checks if URL path regexp contains named groups, and splits them in separate paths to be compatible with OpenAPI paths
@@ -217,7 +217,7 @@ func validateComments(pass *analysis.Pass) ([]string, map[string]string) {
 	return initFunctions, routerPrefixes
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	if specFile == "" {
 		return nil, errors.New("Please supply a path to OpenAPI spec yaml file via -openApiSync.spec")
 	}


### PR DESCRIPTION
#### Summary
Bumps the Golang version to 1.25.8 to align with main server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67154