### PR TITLE
Mark repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Mattermost Go Vet
+# Mattermost Go Vet [Deprecated]
+
+> [!CAUTION]
+> This repository is deprecated and no longer maintained.
+> The code has been merged into the monorepo: https://github.com/mattermost/mattermost/pull/35869
 
 This repository contains mattermost-specific go-vet rules that are used to maintain code consistency in `mattermost`.
 


### PR DESCRIPTION
## Summary

Mark this repository as deprecated now that the code has been merged into the monorepo via https://github.com/mattermost/mattermost/pull/35869.